### PR TITLE
Run event-loop in non-wasm case so app can be run on desktop.

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -5,5 +5,10 @@ int main(int argc, char *argv[])
     Application *app = new Application(argc, argv, QStringLiteral("Slate"));
     if (app->qmlEngine()->rootObjects().isEmpty())
         return 1;
+
+#ifndef Q_OS_WASM
+     app->run();
+#endif
+
     return 0;
 }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -233,7 +233,7 @@ ApplicationWindow {
 
             SplitView.minimumWidth: 200
             SplitView.preferredWidth: defaultPreferredWidth
-            SplitView.maximumWidth: window.width / 3
+            SplitView.maximumWidth: Math.max(window.width / 3, SplitView.minimumWidth)
 
             Ui.ColourPanel {
                 id: colourPanel

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -217,11 +217,15 @@ qt_add_qml_module(slate
         tilesetswatchimage.h
         undocommand.h
         undocommand.cpp
+)
+
+if(EMSCRIPTEN)
+    target_sources(slate PUBLIC   
         webutils.h
         webutils.cpp
         qtwebutils.h
-        qtwebutils.cpp
-)
+        qtwebutils.cpp)
+endif()
 
 find_package(Qt6 COMPONENTS Core)
 find_package(Qt6 COMPONENTS Gui)

--- a/lib/qtwebutils.cpp
+++ b/lib/qtwebutils.cpp
@@ -30,7 +30,7 @@ bool qtwebutils::loadFileToFileSystem(const QString &accept, const QString &dest
     auto fileData = new LoadFileData();
 
     QWasmLocalFileAccess::openFile(accept.toStdString(),
-        [](int fileCount) { Q_ASSERT(fileCount == 1); },
+        [](int fileCount) {;},
         [fileData](uint64_t size, const std::string name) -> char * {
             fileData->name = QString::fromStdString(name);
             fileData->buffer.resize(size);


### PR DESCRIPTION
Fix couples of crashes in debug build:
- closing file dialog wihthout picking any file were causing assertion to fail
- splitview maxwidth could be smaller than minwidth, which fails assertion in QtCore